### PR TITLE
Feat/payment - 결제기능 구현

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -30,6 +30,7 @@ export default [
     rules: {
       'no-unused-vars': 'warn',
       'no-undef': 'error',
+      'no-extra-boolean-cast': 'off',
       'no-relative-import-paths/no-relative-import-paths': [
         'warn',
         { allowSameFolder: false, prefix: '@', rootDir: 'src' },

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "typescript-eslint": "^8.25.0",
     "webpack": "^5.98.0",
     "webpack-cli": "^6.0.1",
-    "webpack-dev-server": "^5.2.0"
+    "webpack-dev-server": "^5.2.0",
+    "@tosspayments/tosspayments-sdk": "^2.3.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@babel/runtime-corejs3": "^7.26.9",
     "@eslint/js": "^9.21.0",
     "@pmmmwh/react-refresh-webpack-plugin": "^0.5.15",
+    "@simbathesailor/use-what-changed": "^2.0.0",
     "@types/react": "^19.0.10",
     "@types/react-dom": "^19.0.4",
     "@webpack-cli/generators": "^3.0.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -103,6 +103,9 @@ devDependencies:
   '@simbathesailor/use-what-changed':
     specifier: ^2.0.0
     version: 2.0.0(react@19.0.0)
+  '@tosspayments/tosspayments-sdk':
+    specifier: ^2.3.4
+    version: 2.3.4
   '@types/react':
     specifier: ^19.0.10
     version: 19.0.10
@@ -2374,6 +2377,10 @@ packages:
   /@tootallnate/once@2.0.0:
     resolution: {integrity: sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==}
     engines: {node: '>= 10'}
+    dev: true
+
+  /@tosspayments/tosspayments-sdk@2.3.4:
+    resolution: {integrity: sha512-YypRXqS+9XtQew5TQBa21Ww8Z7QH+fOkuedfH/BaomsCqBv3qS4wMNCSYrq8pxQ7NBOOuPDw0DLvY7Bg5FWNmQ==}
     dev: true
 
   /@tufjs/canonical-json@1.0.0:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -100,6 +100,9 @@ devDependencies:
   '@pmmmwh/react-refresh-webpack-plugin':
     specifier: ^0.5.15
     version: 0.5.15(react-refresh@0.16.0)(webpack-dev-server@5.2.0)(webpack@5.98.0)
+  '@simbathesailor/use-what-changed':
+    specifier: ^2.0.0
+    version: 2.0.0(react@19.0.0)
   '@types/react':
     specifier: ^19.0.10
     version: 19.0.10
@@ -2264,6 +2267,14 @@ packages:
       tuf-js: 1.1.7
     transitivePeerDependencies:
       - supports-color
+    dev: true
+
+  /@simbathesailor/use-what-changed@2.0.0(react@19.0.0):
+    resolution: {integrity: sha512-ulBNrPSvfho9UN6zS2fii3AsdEcp2fMaKeqUZZeCNPaZbB6aXyTUhpEN9atjMAbu/eyK3AY8L4SYJUG62Ekocw==}
+    peerDependencies:
+      react: '>=16'
+    dependencies:
+      react: 19.0.0
     dev: true
 
   /@standard-schema/utils@0.3.0:
@@ -7591,7 +7602,6 @@ packages:
   /react@19.0.0:
     resolution: {integrity: sha512-V8AVnmPIICiWpGfm6GLzCR/W5FXLchHop40W4nXBmdlEceh16rCN8O8LNWm5bh5XUX91fh7KpA+W0TgMKmgTpQ==}
     engines: {node: '>=0.10.0'}
-    dev: false
 
   /read-cache@1.0.0:
     resolution: {integrity: sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==}

--- a/src/api/comment.ts
+++ b/src/api/comment.ts
@@ -15,5 +15,5 @@ export const addComment = (commentData: Comment) =>
   withSupabaseHandler(supabase.from('Comments').insert([commentData]));
 
 /**  영화 댓글 삭제  */
-export const deleteComment = ({ movieId, userId }: DeleteCommentParams) =>
-  withSupabaseHandler(supabase.from('Comments').delete().eq('movie_id', movieId).eq('user_id', userId));
+export const deleteComment = ({ userId, commentId }: DeleteCommentParams) =>
+  withSupabaseHandler(supabase.from('Comments').delete().eq('id', commentId).eq('user_id', userId));

--- a/src/api/comment.ts
+++ b/src/api/comment.ts
@@ -4,7 +4,11 @@ import { withSupabaseHandler } from '@/api/utils';
 
 /**  영화 댓글 조회  */
 export const fetchComments = (movieId: number) =>
-  withSupabaseHandler(supabase.from('Comments').select('*').eq('movie_id', movieId));
+  withSupabaseHandler(
+    supabase.from('Comments').select('*').eq('movie_id', movieId).order('created_at', {
+      ascending: true,
+    }),
+  );
 
 /** 영화 댓글 추가 */
 export const addComment = (commentData: Comment) =>

--- a/src/api/pay.ts
+++ b/src/api/pay.ts
@@ -1,0 +1,13 @@
+import { supabase } from '@/lib/supabaseClient';
+import { withSupabaseHandler } from '@/api/utils';
+import { AddPaymentData } from '@/types/pay';
+
+// 결제 조회
+export const fetchPayment = ({ userId, movieId }: { userId: string; movieId: number }) =>
+  withSupabaseHandler(supabase.from('Pay').select('*').eq('user_id', userId).eq('movie_id', movieId));
+
+// 결제 추가
+export const addPayment = ({ userId, movieId, title, imgUrl, price }: AddPaymentData) =>
+  withSupabaseHandler(
+    supabase.from('Pay').insert([{ user_id: userId, movie_id: movieId, title, img_url: imgUrl, price }]),
+  );

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -2,6 +2,7 @@ import { SetStateAction, useEffect, useState } from 'react';
 import { useLocation, Link } from 'react-router-dom';
 import useDebounce from '@/hooks/useDebounce';
 import useQueryState from '@/hooks/routing/useQueryParams';
+import { useWhatChanged } from '@simbathesailor/use-what-changed';
 
 const SearchBar = () => {
   const { pathname } = useLocation();
@@ -17,8 +18,12 @@ const SearchBar = () => {
   };
 
   useEffect(() => {
-    setQueryParam(debouncedKeyword);
+    if (!!debouncedKeyword) {
+      setQueryParam(debouncedKeyword);
+    }
   }, [debouncedKeyword]);
+
+  useWhatChanged([queryParam, keyword]);
 
   return (
     <>

--- a/src/hooks/query/useActor.ts
+++ b/src/hooks/query/useActor.ts
@@ -6,15 +6,10 @@ import { fetchCredit } from '@/api/actor';
 export const useGetCreditQuery = (movieId: number, queryParams: baseSearchParam) =>
   useQuery({
     queryFn: () => fetchCredit(movieId, queryParams),
-    queryKey: ActorQueryKeys.getMany('credits', queryParams),
+    queryKey: ActorQueryKeys.getOne(movieId),
   });
 
 export const ActorQueryKeys = {
   all: ['actor'],
-  getMany: (getCategory: string, queryParams?: any) => [
-    ...ActorQueryKeys.all,
-    'getMany',
-    getCategory,
-    JSON.stringify(queryParams),
-  ],
+  getOne: (movieId: number) => [...ActorQueryKeys.all, 'getOne', movieId],
 };

--- a/src/hooks/query/useFavorite.ts
+++ b/src/hooks/query/useFavorite.ts
@@ -13,7 +13,7 @@ export const useGetFavoriteQuery = () =>
 export const useGetFavoriteByMovieQuery = (movieId: number, userId: string) =>
   useQuery({
     queryFn: () => fetchFavoritesByMovie({ movieId, userId }),
-    queryKey: FavoriteQuery.all,
+    queryKey: FavoriteQuery.getOne(movieId),
     enabled: !!movieId && !!userId,
   });
 
@@ -54,5 +54,6 @@ export const useDeleteFavoriteMutation = (options?: UseMutationOptions<null, Err
 };
 
 export const FavoriteQuery = {
-  all: ['favorite'],
+  all: ['favorite'] as const,
+  getOne: (movieId: number) => [...FavoriteQuery.all, 'getOne', movieId] as const,
 };

--- a/src/hooks/query/usePay.ts
+++ b/src/hooks/query/usePay.ts
@@ -1,0 +1,28 @@
+import { addPayment, fetchPayment } from '@/api/pay';
+import { AddPaymentData } from '@/types/pay';
+import { useMutation, UseMutationOptions, useQuery } from '@tanstack/react-query';
+
+/** 결제 조회  */
+export const useGetPayQuery = (userId: string, movieId: number) =>
+  useQuery({
+    enabled: !!userId && !!movieId,
+    queryFn: () => fetchPayment({ userId, movieId }),
+    queryKey: PaymentQuery.getOne(movieId),
+  });
+
+/** 결제 추가  */
+export const usePostPayMutation = (options?: UseMutationOptions<null, Error, AddPaymentData>) =>
+  useMutation({
+    mutationFn: addPayment,
+    onSuccess: (data, variables, context) => {
+      options?.onSuccess?.(data, variables, context);
+    },
+    onError: (error, variables, context) => {
+      options?.onError?.(error, variables, context);
+    },
+  });
+
+export const PaymentQuery = {
+  all: ['payment'] as const,
+  getOne: (movieId: number) => [...PaymentQuery.all, 'getOne', movieId] as const,
+};

--- a/src/hooks/routing/useQueryParams.ts
+++ b/src/hooks/routing/useQueryParams.ts
@@ -12,7 +12,7 @@ const useQueryState = <T extends string | number | boolean>(key: string, default
   const paramValue = queryParams.get(key);
 
   if (!paramValue) {
-    currentValue = defaultValue as T;
+    currentValue = (defaultValue || '') as T;
   } else if (typeof paramValue === 'number') {
     currentValue = Number(paramValue) as T;
   } else if (typeof paramValue === 'boolean') {
@@ -24,10 +24,12 @@ const useQueryState = <T extends string | number | boolean>(key: string, default
   // 업데이트
   const updateSearchParams = (newParams: Record<string, string>) => {
     Object.entries(newParams).forEach(([key, value]) => {
-      if (value) {
-        queryParams.set(key, value);
-      } else {
+      const isEmptyValue = value === 'undefined' || value === 'null' || value === '';
+
+      if (isEmptyValue) {
         queryParams.delete(key);
+      } else {
+        queryParams.set(key, value);
       }
     });
   };

--- a/src/lib/database.types.ts
+++ b/src/lib/database.types.ts
@@ -60,6 +60,36 @@ export type Database = {
         };
         Relationships: [];
       };
+      Pay: {
+        Row: {
+          created_at: string;
+          id: number;
+          img_url: string | null;
+          movie_id: number | null;
+          price: number;
+          title: string | null;
+          user_id: string | null;
+        };
+        Insert: {
+          created_at?: string;
+          id?: number;
+          img_url?: string | null;
+          movie_id?: number | null;
+          price: number;
+          title?: string | null;
+          user_id?: string | null;
+        };
+        Update: {
+          created_at?: string;
+          id?: number;
+          img_url?: string | null;
+          movie_id?: number | null;
+          price?: number;
+          title?: string | null;
+          user_id?: string | null;
+        };
+        Relationships: [];
+      };
       Todos: {
         Row: {
           content: string | null;

--- a/src/pages/Detail/components/Comments.tsx
+++ b/src/pages/Detail/components/Comments.tsx
@@ -95,13 +95,15 @@ const Comments = ({ movieId }: { movieId: number }) => {
     };
   }, [movieId]);
 
+  const hasReview = !!comment.review.length;
+
   return (
     <div>
       <ul className="min-h-[400px] border p-3">
         {comments.data?.map((comment) => (
           <li
             key={comment.id}
-            className={clsx('mb-4 max-w-[80%] rounded-[20px] px-4 py-3 relative', {
+            className={clsx('mb-4 max-w-[80%] rounded-[20px] px-4 py-3 relative group', {
               'ml-auto bg-gray-400 text-white': comment.user_name === userEmail,
               'bg-gray-100 text-gray-900': comment.user_name !== userEmail,
             })}
@@ -119,7 +121,7 @@ const Comments = ({ movieId }: { movieId: number }) => {
               <button
                 type="button"
                 onClick={() => handleDeleteComment(comment.id)}
-                className=" absolute right-[-5px] top-[-5px] bg-gray-600 rounded-[50%] w-4 h-4 text-xs flex items-center justify-center"
+                className="absolute right-[-5px] top-[-5px] bg-gray-500 group-hover:bg-white rounded-[50%] w-4 h-4 text-xs flex items-center justify-center transition-colors group-hover:text-gray-600"
               >
                 x
               </button>
@@ -128,9 +130,24 @@ const Comments = ({ movieId }: { movieId: number }) => {
         ))}
       </ul>
       {/* 폼 */}
-      <div className="flex">
-        <textarea id="review" value={comment.review} onChange={handleReviewChange} className=" text-black" />
-        <button type="button" onClick={handleSubmitComment} className="border px-2">
+      <div className="flex gap-2 mt-4">
+        <textarea
+          id="review"
+          value={comment.review}
+          onChange={handleReviewChange}
+          placeholder="대화에 참여해보세요."
+          className="flex-1 p-1 text-black border rounded-lg resize-none focus:outline-none focus:ring-2 focus:ring-blue-500"
+          rows={1}
+        />
+        <button
+          type="button"
+          onClick={handleSubmitComment}
+          disabled={!hasReview}
+          className={clsx('px-4 py-2 text-white rounded-lg transition-colors duration-200 h-fit', {
+            'bg-blue-500 hover:bg-blue-600': hasReview,
+            'bg-gray-400 cursor-not-allowed': !hasReview,
+          })}
+        >
           보내기
         </button>
       </div>

--- a/src/pages/Detail/components/Comments.tsx
+++ b/src/pages/Detail/components/Comments.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { useAddCommentMutation, useDeleteCommentMutation, useGetCommentsQuery } from '@/hooks/query/useComment';
 import { useAuth } from '@/context/AuthContext';
 import { supabase } from '@/lib/supabaseClient';
+import clsx from 'clsx';
 
 const Comments = ({ movieId }: { movieId: number }) => {
   const initialCommentState = { review: '', vote: 0 };
@@ -41,13 +42,13 @@ const Comments = ({ movieId }: { movieId: number }) => {
     setComment(initialCommentState);
   };
 
-  const handleDeleteComment = () => {
-    if (!userId) {
-      console.log('userId undefined!');
-      return;
-    }
+  const handleDeleteComment = (commentId: number) => {
+    if (!userId) return;
 
-    const deleteData = { userId, movieId };
+    const isConfirmed = confirm('메시지를 삭제하시겠습니까?');
+    if (!isConfirmed) return;
+
+    const deleteData = { userId, commentId };
     deleteCommnet.mutate(deleteData, {
       onSuccess: (data) => {
         // 추가적인 성공 처리
@@ -96,39 +97,43 @@ const Comments = ({ movieId }: { movieId: number }) => {
 
   return (
     <div>
-      Comments
-      {/* [TODO] UI 개선 */}
-      <div className="flex">
-        <label htmlFor="vote">평점 </label>
-        <input
-          type="number"
-          id="vote"
-          min={0}
-          max={10}
-          value={comment.vote}
-          onChange={handleVoteChange}
-          className=" text-black"
-        />
-        <label htmlFor="review">의견 </label>
-        <textarea id="review" value={comment.review} onChange={handleReviewChange} className=" text-black" />
-        <button type="button" onClick={handleSubmitComment} className="border px-2">
-          등록
-        </button>
-
-        <button type="button" onClick={handleDeleteComment} className="border px-2">
-          삭제
-        </button>
-      </div>
-      <ul>
+      <ul className="min-h-[400px] border p-3">
         {comments.data?.map((comment) => (
-          <li key={comment.id} className="border">
-            <div>{comment.user_name}</div>
-            <div>
-              평점 : {comment.vote} / 리뷰 : {comment.review}
+          <li
+            key={comment.id}
+            className={clsx('mb-4 max-w-[80%] rounded-[20px] px-4 py-3 relative', {
+              'ml-auto bg-gray-400 text-white': comment.user_name === userEmail,
+              'bg-gray-100 text-gray-900': comment.user_name !== userEmail,
+            })}
+          >
+            <div
+              className={clsx('mb-1 text-sm', {
+                'text-gray-200': comment.user_name === userEmail,
+                'text-gray-600': comment.user_name !== userEmail,
+              })}
+            >
+              {comment.user_name}
             </div>
+            <div className="text-base">{comment.review}</div>
+            {comment.user_name === userEmail && (
+              <button
+                type="button"
+                onClick={() => handleDeleteComment(comment.id)}
+                className=" absolute right-[-5px] top-[-5px] bg-gray-600 rounded-[50%] w-4 h-4 text-xs flex items-center justify-center"
+              >
+                x
+              </button>
+            )}
           </li>
         ))}
       </ul>
+      {/* 폼 */}
+      <div className="flex">
+        <textarea id="review" value={comment.review} onChange={handleReviewChange} className=" text-black" />
+        <button type="button" onClick={handleSubmitComment} className="border px-2">
+          보내기
+        </button>
+      </div>
     </div>
   );
 };

--- a/src/pages/Detail/components/DetailHeader.tsx
+++ b/src/pages/Detail/components/DetailHeader.tsx
@@ -58,6 +58,11 @@ const DetailHeader = ({ movieId }: { movieId: number }) => {
     return window.open(`/payment/checkout?${params}`, '_blank', 'width=770,height=730');
   };
 
+  const goToWatchPage = (videoId: string) => {
+    if (!videoId) return;
+    return goTo('/watch/:movieId', { movieId }, { play: videoId });
+  };
+
   useEffect(() => {
     const channel = new BroadcastChannel('payment_success');
 
@@ -141,7 +146,7 @@ const DetailHeader = ({ movieId }: { movieId: number }) => {
 
           <div>
             {videoId && (
-              <button type="button" onClick={() => goTo('/watch/:movieId', { movieId }, { play: videoId })}>
+              <button type="button" onClick={() => goToWatchPage(videoId)}>
                 ▶️ 미리보기
               </button>
             )}
@@ -150,17 +155,21 @@ const DetailHeader = ({ movieId }: { movieId: number }) => {
           {renderMovieInfo()}
           <p>{movieInfo?.overview}</p>
 
-          <div className="flex justify-between">
-            <button type="button" className="bg-red-500 px-4 py-0 mt-5 rounded-sm" onClick={handlePayment}>
+          <div className="flex justify-between items-center">
+            <button
+              type="button"
+              className="bg-red-500 hover:bg-red-600 px-6 py-2 mt-5 rounded-md transition-colors"
+              onClick={isPurchased ? () => goToWatchPage(videoId!) : handlePayment}
+            >
               {isPurchased ? (
-                <div className="flex align-middle gap-1">
+                <div className="flex items-center gap-2">
                   <Play fill="white" />
-                  감상하기
+                  <span className="font-medium">감상하기</span>
                 </div>
               ) : (
-                <div className="flex align-middle gap-1">
+                <div className="flex items-center gap-2">
                   <MonitorPlay />
-                  구매하기
+                  <span className="font-medium">구매하기</span>
                 </div>
               )}
             </button>

--- a/src/pages/Detail/components/DetailHeader.tsx
+++ b/src/pages/Detail/components/DetailHeader.tsx
@@ -11,122 +11,161 @@ import {
 } from '@/hooks/query/useFavorite';
 import { useGetVideoQuery } from '@/hooks/query/useVideo';
 import useNavigateTo from '@/hooks/routing/useUrlNavigation';
+import { PaymentQuery, useGetPayQuery } from '@/hooks/query/usePay';
+import { Play, MonitorPlay } from 'lucide-react';
+import { useEffect } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
 
 const DetailHeader = ({ movieId }: { movieId: number }) => {
-  const movieInfo = useGetDetailMovieQuery(movieId, { language: TMDB_LANGUAGE_KR });
+  const queryClient = useQueryClient();
   const goTo = useNavigateTo();
+  const { session } = useAuth();
+  const userId = session?.user.id;
 
-  const getUser = useAuth();
-  const userId = getUser.session?.user.id;
+  const { data: movieInfo } = useGetDetailMovieQuery(movieId, { language: TMDB_LANGUAGE_KR });
+  const { data: { key: videoId } = {} } = useGetVideoQuery(movieId);
+  const { data: paymentData } = useGetPayQuery(userId!, movieId);
+  const { data: favorites } = useGetFavoriteByMovieQuery(movieId!, userId!);
 
   const addFavorite = useAddFavoriteMutation();
-  const deleteCommnet = useDeleteFavoriteMutation();
-  const { data: { key: videoId } = {} } = useGetVideoQuery(movieId);
+  const deleteFavorite = useDeleteFavoriteMutation();
 
-  const { data: favorites } = useGetFavoriteByMovieQuery(movieId!, userId!);
   const isFavoriteAdded = !!favorites?.length;
+  const isPurchased = !!paymentData?.length;
 
   const handleAddFavorite = () => {
-    const movieData = movieInfo.data;
-    if (!movieData?.title || !movieData?.poster_path || !userId) {
-      return;
-    }
+    if (!movieInfo?.title || !movieInfo?.poster_path || !userId) return;
 
     if (isFavoriteAdded) {
-      deleteCommnet.mutate({ userId, movieId });
+      deleteFavorite.mutate({ userId, movieId });
     } else {
       addFavorite.mutate({
         movie_id: movieId,
         user_id: userId,
-        img_url: movieData.poster_path,
-        title: movieData.title,
+        img_url: movieInfo.poster_path,
+        title: movieInfo.title,
       });
     }
   };
 
+  const handlePayment = () => {
+    const params = new URLSearchParams({
+      movieId: movieId.toString(),
+      title: movieInfo?.title || '',
+      imgUrl: movieInfo?.poster_path || '',
+    });
+
+    return window.open(`/payment/checkout?${params}`, '_blank', 'width=770,height=730');
+  };
+
+  useEffect(() => {
+    const channel = new BroadcastChannel('payment_success');
+
+    channel.onmessage = (event) => {
+      if (event.data.type === 'INVALIDATE_QUERIES') {
+        queryClient.invalidateQueries({
+          queryKey: PaymentQuery.getOne(movieId),
+          exact: true,
+        });
+      }
+    };
+
+    return () => channel.close();
+  }, [movieId, queryClient]);
+
+  const renderMovieInfo = () => (
+    <div className="flex align-center gap-1">
+      <p className="mb-1">✭ {movieInfo?.vote_average}</p>
+      <p className="px-2">•</p>
+      <p className="mb-1">{movieInfo?.release_date}</p>
+      <p className="px-2">•</p>
+      <p className="mb-1">{movieInfo?.genres.map((genre) => <span key={genre.id}>{genre.name} </span>)}</p>
+      <p className="px-2">•</p>
+      <p className="mb-1">{movieInfo?.runtime}m</p>
+    </div>
+  );
+
+  const renderActionButtons = () => (
+    <div className="flex gap-2">
+      <button
+        type="button"
+        onClick={handleAddFavorite}
+        className="w-[70px] h-[70px] flex flex-col justify-center hover:bg-white/30"
+      >
+        {isFavoriteAdded ? (
+          <>
+            <span>✔️</span>
+            <span>추가됨</span>
+          </>
+        ) : (
+          <>
+            <span>+</span>
+            <span>찜하기</span>
+          </>
+        )}
+      </button>
+      <button type="button" className="w-[70px] h-[70px] flex flex-col justify-center bg-white-10 hover:bg-white/30">
+        <span>✍️</span>
+        <span>평가하기</span>
+      </button>
+      <button type="button" className="w-[70px] h-[70px] flex flex-col justify-center bg-white-10 hover:bg-white/30">
+        <span>📎</span>
+        <span>공유</span>
+      </button>
+    </div>
+  );
+
   return (
     <header
       className={clsx('h-96 bg-cover', {
-        'bg-center': movieInfo.data?.backdrop_path,
-        'bg-gray-900': !movieInfo.data?.backdrop_path,
+        'bg-center': movieInfo?.backdrop_path,
+        'bg-gray-900': !movieInfo?.backdrop_path,
       })}
       style={{
-        backgroundImage: movieInfo.data?.backdrop_path
-          ? `linear-gradient(rgba(0, 0, 0, 0.9), rgba(0, 0, 0, 0.5)), url(${getImageUrl(movieInfo.data?.backdrop_path, 'w500')})`
+        backgroundImage: movieInfo?.backdrop_path
+          ? `linear-gradient(rgba(0, 0, 0, 0.9), rgba(0, 0, 0, 0.5)), url(${getImageUrl(movieInfo.backdrop_path, 'w500')})`
           : 'none',
       }}
     >
       <div className="flex px-36 w-full h-full p-6">
         <div className="relative h-full min-w-[224px] mr-10">
-          <PosterImage posterPath={movieInfo.data?.poster_path} size="w500" />
+          <PosterImage posterPath={movieInfo?.poster_path} size="w500" />
         </div>
 
         <div className="flex flex-col justify-between w-full">
           <div className="flex justify-between">
             <h1 className="text-2xl">
-              {movieInfo.data?.title} - {movieId}
+              {movieInfo?.title} - {movieId}
             </h1>
-            <div className="flex gap-2">
-              <button
-                type="button"
-                onClick={handleAddFavorite}
-                className={'w-[70px] h-[70px] flex flex-col justify-center hover:bg-white/30'}
-              >
-                {isFavoriteAdded ? (
-                  <>
-                    <span>✔️</span>
-                    <span>추가됨</span>
-                  </>
-                ) : (
-                  <>
-                    <span>+</span>
-                    <span>찜하기</span>
-                  </>
-                )}
-              </button>
-              <button
-                type="button"
-                className="w-[70px] h-[70px] flex flex-col justify-center bg-white-10 hover:bg-white/30"
-              >
-                <span>✍️</span>
-                <span>평가하기</span>
-              </button>
-              <button
-                type="button"
-                className="w-[70px] h-[70px] flex flex-col justify-center bg-white-10 hover:bg-white/30"
-              >
-                <span>📎</span>
-                <span>공유</span>
-              </button>
-            </div>
           </div>
 
           <div>
             {videoId && (
-              <button
-                type="button"
-                onClick={() => {
-                  goTo('/watch/:movieId', { movieId }, { play: videoId });
-                }}
-              >
+              <button type="button" onClick={() => goTo('/watch/:movieId', { movieId }, { play: videoId })}>
                 ▶️ 미리보기
               </button>
             )}
           </div>
-          <div className="flex gap-1">
-            <p className="mb-1">✭ {movieInfo.data?.vote_average} </p>
-            <p className="px-2">•</p>
-            <p className="mb-1"> {movieInfo.data?.release_date}</p>
-            <p className="px-2">•</p>
-            <p className="mb-1">{movieInfo.data?.genres.map((genre) => <span key={genre.id}>{genre.name} </span>)}</p>
-            <p className="px-2">•</p>
-            <p className="mb-1"> {movieInfo.data?.runtime}m </p>
-          </div>
-          <p>{movieInfo.data?.overview}</p>
 
-          <button type="button" className="bg-red-500 p-2 mt-2 rounded-sm">
-            이용권 구독하기
-          </button>
+          {renderMovieInfo()}
+          <p>{movieInfo?.overview}</p>
+
+          <div className="flex justify-between">
+            <button type="button" className="bg-red-500 px-4 py-0 mt-5 rounded-sm" onClick={handlePayment}>
+              {isPurchased ? (
+                <div className="flex align-middle gap-1">
+                  <Play fill="white" />
+                  감상하기
+                </div>
+              ) : (
+                <div className="flex align-middle gap-1">
+                  <MonitorPlay />
+                  구매하기
+                </div>
+              )}
+            </button>
+            {renderActionButtons()}
+          </div>
         </div>
       </div>
     </header>

--- a/src/pages/Detail/index.tsx
+++ b/src/pages/Detail/index.tsx
@@ -57,8 +57,8 @@ export default function Detail() {
           </div>
           {/* 출연진 */}
           {mode === 'info' && (
-            <>
-              <div className="py-5">
+            <div className="flex justify-between  gap-5">
+              <div className="py-5 w-2/3 border">
                 <h2 className="font-semibold">감독/출연진</h2>
 
                 <ul className="grid grid-cols-2 gap-4 mt-5">
@@ -75,11 +75,11 @@ export default function Detail() {
                   ))}
                 </ul>
               </div>
-              <div className="py-5">
+              <div className="py-5 w-1/3 ">
                 <h2 className="font-semibold">사용자 리뷰</h2>
                 <Comments movieId={movieId} />
               </div>
-            </>
+            </div>
           )}
 
           {/* 관련 영화 */}

--- a/src/pages/Pay/Checkout.tsx
+++ b/src/pages/Pay/Checkout.tsx
@@ -1,0 +1,125 @@
+import { useEffect, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import { loadTossPayments, ANONYMOUS } from '@tosspayments/tosspayments-sdk';
+import '@/pages/Pay/pay.css';
+
+const clientKey = 'test_gck_docs_Ovk5rk1EwkEbP0W43n07xlzm';
+const customerKey = '5w7v1KP1o4XRzkLogkn1F';
+
+function CheckoutPage() {
+  const [amount, setAmount] = useState({
+    currency: 'KRW',
+    value: 200,
+  });
+  const [ready, setReady] = useState<boolean>(false);
+  const [widgets, setWidgets] = useState<any | null>(null);
+
+  const [searchParams] = useSearchParams();
+
+  const handlePayment = async () => {
+    try {
+      // ------ '결제하기' 버튼 누르면 결제창 띄우기 ------
+      // 결제를 요청하기 전에 orderId, amount를 서버에 저장하세요.
+      // 결제 과정에서 악의적으로 결제 금액이 바뀌는 것을 확인하는 용도입니다.
+      await widgets.requestPayment({
+        orderId: '5vnitP6t1I_VsgeNWdgGt',
+        orderName: '개별 영화 구매',
+        successUrl: window.location.origin + `/payment/success?${searchParams}`,
+        failUrl: window.location.origin + '/payment/fail',
+        customerEmail: 'customer123@gmail.com',
+        customerName: '김토스',
+        customerMobilePhone: '01012341234',
+      });
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  useEffect(() => {
+    async function fetchPaymentWidgets() {
+      // ------  결제위젯 초기화 ------
+      const tossPayments = await loadTossPayments(clientKey);
+      // 회원 결제
+      const widgets = tossPayments.widgets({
+        customerKey,
+      });
+      // 비회원 결제
+      // const widgets = tossPayments.widgets({ customerKey: ANONYMOUS });
+
+      setWidgets(widgets);
+    }
+
+    fetchPaymentWidgets();
+  }, [clientKey, customerKey]);
+
+  useEffect(() => {
+    async function renderPaymentWidgets() {
+      if (widgets == null) {
+        return;
+      }
+      // ------ 주문의 결제 금액 설정 ------
+      await widgets.setAmount(amount);
+
+      await Promise.all([
+        // ------  결제 UI 렌더링 ------
+        widgets.renderPaymentMethods({
+          selector: '#payment-method',
+          variantKey: 'DEFAULT',
+        }),
+        // ------  이용약관 UI 렌더링 ------
+        widgets.renderAgreement({
+          selector: '#agreement',
+          variantKey: 'AGREEMENT',
+        }),
+      ]);
+
+      setReady(true);
+    }
+
+    renderPaymentWidgets();
+  }, [widgets]);
+
+  useEffect(() => {
+    if (widgets == null) {
+      return;
+    }
+
+    widgets.setAmount(amount);
+  }, [widgets, amount]);
+
+  return (
+    <div className="wrapper">
+      <div className="box_section">
+        {/* 결제 UI */}
+        <div id="payment-method" />
+        {/* 이용약관 UI */}
+        <div id="agreement" />
+        {/* 쿠폰 체크박스 */}
+        <div>
+          <div>
+            <label htmlFor="coupon-box">
+              <input
+                id="coupon-box"
+                type="checkbox"
+                aria-checked="true"
+                disabled={!ready}
+                onChange={(event) => {
+                  // ------  주문서의 결제 금액이 변경되었을 경우 결제 금액 업데이트 ------
+                  setAmount((prev) => ({ ...prev, value: event.target.checked ? prev.value - 100 : prev.value + 100 }));
+                }}
+              />
+              <span>100원 쿠폰 적용</span>
+            </label>
+          </div>
+        </div>
+
+        {/* 결제하기 버튼 */}
+        <button className="button" disabled={!ready} onClick={handlePayment}>
+          {amount.value}원 결제하기
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export default CheckoutPage;

--- a/src/pages/Pay/Success.tsx
+++ b/src/pages/Pay/Success.tsx
@@ -1,0 +1,106 @@
+import { useAuth } from '@/context/AuthContext';
+import { PaymentQuery, usePostPayMutation } from '@/hooks/query/usePay';
+import { useQueryClient } from '@tanstack/react-query';
+import { useEffect } from 'react';
+import { useSearchParams } from 'react-router-dom';
+
+function SuccessPage() {
+  const [searchParams] = useSearchParams();
+  const queryClient = useQueryClient();
+
+  const getUser = useAuth();
+  const userId = getUser.session?.user.id;
+
+  const postPay = usePostPayMutation();
+
+  useEffect(() => {
+    function confirm() {
+      const requestData = {
+        movieId: searchParams.get('movieId'),
+        title: searchParams.get('title'),
+        imgUrl: searchParams.get('imgUrl'),
+        price: searchParams.get('amount'),
+      };
+
+      // api
+      return Promise.resolve(requestData);
+    }
+
+    confirm()
+      .then((data) => {
+        const { imgUrl, movieId, title, price } = data;
+
+        postPay.mutate(
+          {
+            userId: userId!,
+            movieId: +movieId!,
+            title: title!,
+            imgUrl: imgUrl!,
+            price: +price!,
+          },
+          {
+            onSuccess: () => {
+              // BroadcastChannel을 통해 메시지 전송
+              const channel = new BroadcastChannel('payment_success');
+              channel.postMessage({
+                type: 'INVALIDATE_QUERIES',
+                movieId: movieId,
+              });
+              channel.close();
+
+              // 현재 창에서도 쿼리 무효화
+              queryClient.invalidateQueries({
+                queryKey: PaymentQuery.getOne(+movieId!),
+                exact: true,
+              });
+            },
+          },
+        );
+      })
+      .catch((error) => {
+        // navigate(`/payment/fail?code=${error.code}&message=${error.message}`);
+      });
+  }, [searchParams]);
+
+  return (
+    <>
+      <div className="box_section" style={{ width: '600px' }}>
+        <div className="flex flex-col items-center justify-center">
+          <img width="100px" src="https://static.toss.im/illusts/check-blue-spot-ending-frame.png" />
+          <h2>결제를 완료했어요</h2>
+        </div>
+        <div className="p-grid typography--p" style={{ marginTop: '50px' }}>
+          <div className="p-grid-col text--left">
+            <b>결제금액</b>
+          </div>
+          <div className="p-grid-col text--right" id="amount">
+            {`${Number(searchParams.get('amount')).toLocaleString()}원`}
+          </div>
+        </div>
+        <div className="p-grid typography--p" style={{ marginTop: '10px' }}>
+          <div className="p-grid-col text--left">
+            <b>주문번호</b>
+          </div>
+          <div className="p-grid-col text--right" id="orderId">
+            {`${searchParams.get('orderId')}`}
+          </div>
+        </div>
+        <div className="p-grid typography--p" style={{ marginTop: '10px' }}>
+          <div className="p-grid-col text--left">
+            <b>paymentKey</b>
+          </div>
+          <div className="p-grid-col text--right" id="paymentKey" style={{ whiteSpace: 'initial', width: '250px' }}>
+            {`${searchParams.get('paymentKey')}`}
+          </div>
+        </div>
+        <div className="p-grid-col mt-16">
+          <button className="button p-grid-col5" onClick={() => window.close()} style={{ margin: '0 auto' }}>
+            확인
+          </button>
+        </div>
+      </div>
+    </>
+  );
+}
+
+export default SuccessPage;

--- a/src/pages/Pay/pay.css
+++ b/src/pages/Pay/pay.css
@@ -1,0 +1,623 @@
+body {
+  background-color: #e8f3ff;
+}
+.p {
+  padding: 0;
+  margin: 0;
+  font-family:
+    Toss Product Sans,
+    -apple-system,
+    BlinkMacSystemFont,
+    Bazier Square,
+    Noto Sans KR,
+    Segoe UI,
+    Apple SD Gothic Neo,
+    Roboto,
+    Helvetica Neue,
+    Arial,
+    sans-serif,
+    Apple Color Emoji,
+    Segoe UI Emoji,
+    Segoe UI Symbol,
+    Noto Color Emoji;
+  color: #4e5968;
+  word-break: keep-all;
+  word-wrap: break-word;
+}
+.wrapper {
+  max-width: 800px;
+  margin: 0 auto;
+}
+.title {
+  margin: 0 0 4px;
+  font-size: 24px;
+  font-weight: 600;
+  color: #4e5968;
+}
+.box_section {
+  background-color: white;
+  border-radius: 10px;
+  box-shadow:
+    0 10px 20px rgb(0 0 0 / 1%),
+    0 6px 6px rgb(0 0 0 / 6%);
+  padding: 50px 50px 50px 50px;
+  margin-top: 30px;
+  margin-right: auto;
+  margin-left: auto;
+  color: #333d4b;
+  align-items: center;
+  text-align: center;
+  overflow-x: auto; /* Add this property for horizontal scrolling */
+  white-space: nowrap; /* Prevent text wrapping */
+}
+:root {
+  --inverseGrey50: #202027;
+  --inverseGrey100: #2c2c35;
+  --inverseGrey200: #3c3c47;
+  --inverseGrey300: #4d4d59;
+  --inverseGrey400: #62626d;
+  --inverseGrey500: #7e7e87;
+  --inverseGrey600: #9e9ea4;
+  --inverseGrey700: #c3c3c6;
+  --inverseGrey800: #e4e4e5;
+  --inverseGrey900: #fff;
+  --background: #fff;
+  --darkBackground: #17171c;
+  --greyBackground: #f2f4f6;
+  --darkGreyBackground: #101013;
+  --layeredBackground: #fff;
+  --darkLayeredBackground: #202027;
+  --floatBackground: #fff;
+  --darkFloatBackground: #2c2c35;
+  --black: #000;
+  --grey50: #f9fafb;
+  --grey100: #f2f4f6;
+  --grey200: #e5e8eb;
+  --grey300: #d1d6db;
+  --grey400: #b0b8c1;
+  --grey500: #8b95a1;
+  --grey600: #6b7684;
+  --grey700: #4e5968;
+  --grey800: #333d4b;
+  --grey900: #191f28;
+  --greyOpacity50: rgba(0, 23, 51, 0.02);
+  --greyOpacity100: rgba(2, 32, 71, 0.05);
+  --greyOpacity200: rgba(0, 27, 55, 0.1);
+  --greyOpacity300: rgba(0, 29, 58, 0.18);
+  --greyOpacity400: rgba(0, 25, 54, 0.31);
+  --greyOpacity500: rgba(3, 24, 50, 0.46);
+  --greyOpacity600: rgba(0, 19, 43, 0.58);
+  --greyOpacity700: rgba(3, 18, 40, 0.7);
+  --greyOpacity800: rgba(0, 12, 30, 0.8);
+  --greyOpacity900: rgba(2, 9, 19, 0.91);
+  --white: #fff;
+  --blue50: #e8f3ff;
+  --blue100: #c9e2ff;
+  --blue200: #90c2ff;
+  --blue300: #64a8ff;
+  --blue400: #4593fc;
+  --blue500: #3182f6;
+  --blue600: #2272eb;
+  --blue700: #1b64da;
+  --blue800: #1957c2;
+  --blue900: #194aa6;
+}
+
+body,
+html {
+  font-family:
+    Toss Product Sans,
+    Tossface,
+    -apple-system,
+    BlinkMacSystemFont,
+    Bazier Square,
+    Noto Sans KR,
+    Segoe UI,
+    Apple SD Gothic Neo,
+    Roboto,
+    Helvetica Neue,
+    Arial,
+    sans-serif,
+    Apple Color Emoji,
+    Segoe UI Emoji,
+    Segoe UI Symbol,
+    Noto Color Emoji;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  word-break: keep-all;
+  word-wrap: break-word;
+}
+
+*,
+:after,
+:before {
+  box-sizing: border-box;
+}
+
+.button {
+  color: #f9fafb;
+  background-color: #3182f6;
+  margin: 30px 15px 0px 15px;
+  font-size: 15px;
+  font-weight: 600;
+  line-height: 18px;
+  white-space: nowrap;
+  text-align: center;
+  /* vertical-align: middle; */
+  cursor: pointer;
+  border: 0 solid transparent;
+  user-select: none;
+  transition:
+    background 0.2s ease,
+    color 0.1s ease;
+  text-decoration: none;
+  border-radius: 7px;
+  padding: 11px 16px;
+  width: 250px;
+}
+
+.button2 {
+  color: #000000;
+  background-color: #ffffff;
+  margin: 30px 15px 0px 15px;
+  font-size: 15px;
+  font-weight: 600;
+  line-height: 18px;
+  white-space: nowrap;
+  text-align: center;
+  /* vertical-align: middle; */
+  cursor: pointer;
+  border: 1px solid #000000;
+  user-select: none;
+  transition:
+    background 0.2s ease,
+    color 0.1s ease;
+  text-decoration: none;
+  border-radius: 7px;
+  padding: 11px 16px;
+  width: 125px;
+}
+
+.button2.active {
+  background-color: rgb(229 239 255);
+}
+
+.button:hover {
+  color: #fff;
+  background-color: #1b64da;
+}
+
+button:disabled,
+input:disabled {
+  opacity: 80%;
+  cursor: not-allowed;
+}
+
+button,
+input,
+textarea {
+  font-family:
+    Toss Product Sans,
+    -apple-system,
+    BlinkMacSystemFont,
+    Bazier Square,
+    Noto Sans KR,
+    Segoe UI,
+    Apple SD Gothic Neo,
+    Roboto,
+    Helvetica Neue,
+    Arial,
+    sans-serif,
+    Apple Color Emoji,
+    Segoe UI Emoji,
+    Segoe UI Symbol,
+    Noto Color Emoji;
+}
+
+.color--grey800 {
+  color: #333d4b;
+  color: var(--grey800);
+}
+
+.color--grey700 {
+  color: #4e5968;
+  color: var(--grey700);
+}
+
+.color--grey600 {
+  color: #6b7684;
+  color: var(--grey600);
+}
+
+.color--grey500 {
+  color: #8b95a1;
+  color: var(--grey500);
+}
+
+.color--blue500 {
+  color: #3182f6;
+  color: var(--blue500);
+}
+
+.color--blue700 {
+  color: #1b64da;
+  color: var(--blue700);
+}
+
+.bg--white {
+  background-color: #fff;
+  background-color: var(--white);
+}
+
+.bg--grey100 {
+  background-color: #f2f4f6;
+  background-color: var(--grey100);
+}
+
+.bg--greyOpacity100 {
+  background-color: rgba(2, 32, 71, 0.05);
+  background-color: var(--greyOpacity100);
+}
+
+.bg--greyOpacity200 {
+  background-color: rgba(0, 27, 55, 0.1);
+  background-color: var(--greyOpacity200);
+}
+
+.bg--blue50 {
+  background-color: #e8f3ff;
+  background-color: var(--blue50);
+}
+
+:root {
+  --padding-base-vertical: 11px;
+  --padding-base-horizontal: 16px;
+  --padding-t-vertical: 4px;
+  --padding-t-horizontal: 8px;
+  --padding-s-vertical: 7px;
+  --padding-s-horizontal: 12px;
+  --padding-l-vertical: 11px;
+  --padding-l-horizontal: 22px;
+  --padding-xl-vertical: 18px;
+  --padding-xl-horizontal: 24px;
+  --padding-container-base: 48px;
+}
+
+.padding--base {
+  padding: 11px 16px;
+  padding: var(--padding-base-vertical) var(--padding-base-horizontal);
+}
+
+.padding--t {
+  padding: 4px 8px;
+  padding: var(--padding-t-vertical) var(--padding-t-horizontal);
+}
+
+.padding--s {
+  padding: 7px 12px;
+  padding: var(--padding-s-vertical) var(--padding-s-horizontal);
+}
+
+.padding--l {
+  padding: 11px 22px;
+  padding: var(--padding-l-vertical) var(--padding-l-horizontal);
+}
+
+.padding--xl {
+  padding: 18px 24px;
+  padding: var(--padding-xl-vertical) var(--padding-xl-horizontal);
+}
+
+.text--left {
+  text-align: left;
+}
+
+.text--right {
+  text-align: right;
+}
+
+.text--center {
+  text-align: center;
+}
+
+.text--justify {
+  text-align: justify;
+}
+
+:root {
+  --line-height-base: 1.6;
+  --line-height-adjust: 1.3;
+  --font-size-h1: 56px;
+  --font-size-h2: 48px;
+  --font-size-h3: 36px;
+  --font-size-h4: 32px;
+  --font-size-h5: 24px;
+  --font-size-h6: 20px;
+  --font-size-h7: 17px;
+  --font-size-p: 15px;
+  --font-size-sm: 13px;
+  --font-size-small: 13px;
+  --font-size-xsmall: 11px;
+  --font-weight-bold: bold;
+  --font-weight-semibold: 600;
+  --font-weight-medium: 500;
+  --font-weight-regular: normal;
+}
+
+.typography {
+  margin: 0;
+  padding: 0;
+}
+
+.typography--h1,
+.typography--h2,
+.typography--h3,
+.typography--h4 {
+  line-height: 1.3;
+  line-height: var(--line-height-adjust);
+}
+
+.typography--h1 {
+  font-size: 56px;
+  font-size: var(--font-size-h1);
+}
+
+.typography--h2 {
+  font-size: 48px;
+  font-size: var(--font-size-h2);
+}
+
+.typography--h3 {
+  font-size: 36px;
+  font-size: var(--font-size-h3);
+}
+
+.typography--h4 {
+  font-size: 32px;
+  font-size: var(--font-size-h4);
+}
+
+.typography--p {
+  line-height: 1.6;
+  line-height: var(--line-height-base);
+  font-size: 15px;
+  font-size: var(--font-size-p);
+}
+
+:root {
+  --checkable-size: 24px;
+  --checkable-input-top: 3px;
+  --checkable-input-left: 5px;
+  --checkable-input-width: 14px;
+  --checkable-input-height: 10px;
+  --checkable-input-svg: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M1.343 4.574l4.243 4.243 7.07-7.071' fill='transparent' stroke-width='2' stroke='%23FFF' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+  --checkable-label-text-padding: 8px;
+  --indeterminate-checkable-input-top: 7px;
+  --indeterminate-checkable-input-left: 5px;
+  --indeterminate-checkable-input-width: 14px;
+}
+
+:root .checkable--small {
+  --checkable-size: 20px;
+  --checkable-input-top: 2px;
+  --checkable-input-left: 4px;
+  --checkable-input-width: 12px;
+  --checkable-input-height: 9px;
+  --checkable-input-svg: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M1.286 3.645l3.536 3.536 5.892-5.893' fill='transparent' stroke-width='2' stroke='%23FFF' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+  --indeterminate-checkable-input-top: 5px;
+  --indeterminate-checkable-input-left: 4px;
+  --indeterminate-checkable-input-width: 12px;
+}
+
+.checkable {
+  position: relative;
+  display: flex;
+}
+
+.checkable + .checkable {
+  margin-top: 12px;
+}
+
+.checkable--inline {
+  display: inline-block;
+}
+
+.checkable--inline + .checkable--inline {
+  margin-top: 0;
+  margin-left: 18px;
+}
+
+.checkable__label {
+  display: inline-block;
+  max-width: 100%;
+  min-height: 24px;
+  min-height: var(--checkable-size);
+  line-height: 1.6;
+  padding-left: 24px;
+  padding-left: var(--checkable-size);
+  margin-bottom: 0;
+  padding-top: 0;
+  padding-bottom: 0;
+  color: #4e5968;
+  color: var(--grey700);
+  cursor: pointer;
+}
+
+.checkable__input {
+  position: absolute;
+  margin: 0 0 0 -24px;
+  margin: 0 0 0 calc(var(--checkable-size) * -1);
+  top: 4px;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  border: none;
+  cursor: pointer;
+}
+
+.checkable__input:after,
+.checkable__input:before {
+  content: '';
+  position: absolute;
+}
+
+.checkable__input:before {
+  top: -4px;
+  left: 0;
+  width: 24px;
+  width: var(--checkable-size);
+  height: 24px;
+  height: var(--checkable-size);
+  border: 2px solid #d1d6db;
+  border: 2px solid var(--grey300);
+  background-color: #fff;
+  background-color: var(--white);
+  transition:
+    border-color 0.1s ease,
+    background-color 0.1s ease;
+}
+
+.checkable__input:after {
+  opacity: 0;
+  transition: opacity 0.1s ease;
+  top: 3px;
+  top: var(--checkable-input-top);
+  left: 5px;
+  left: var(--checkable-input-left);
+  width: 14px;
+  width: var(--checkable-input-width);
+  height: 10px;
+  height: var(--checkable-input-height);
+  background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M1.343 4.574l4.243 4.243 7.07-7.071' fill='transparent' stroke-width='2' stroke='%23FFF' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+  background-image: var(--checkable-input-svg);
+  background-repeat: no-repeat;
+}
+
+.checkable__input[type='checkbox']:indeterminate:after {
+  top: 7px;
+  top: var(--indeterminate-checkable-input-top);
+  left: 5px;
+  left: var(--indeterminate-checkable-input-left);
+  width: 14px;
+  width: var(--indeterminate-checkable-input-width);
+  height: 0;
+  border: 1px solid #fff;
+  border: 1px solid var(--white);
+  border-radius: 1px;
+  transform: rotate(0);
+}
+
+.checkable__input:focus {
+  outline: 0;
+}
+
+.checkable__input:focus:before,
+.checkable__input:hover:before {
+  background-color: #e8f3ff;
+  background-color: var(--blue50);
+  border-color: #3182f6;
+  border-color: var(--blue500);
+}
+
+.checkable__input:checked:before,
+.checkable__input[type='checkbox']:indeterminate:before {
+  border-color: #3182f6;
+  border-color: var(--blue500);
+  background-color: #3182f6;
+  background-color: var(--blue500);
+}
+
+.checkable__input:checked:after,
+.checkable__input[type='checkbox']:indeterminate:after {
+  opacity: 1;
+}
+
+.checkable__input:disabled:before {
+  background-color: #f2f4f6;
+  background-color: var(--grey100);
+  border-color: rgba(0, 23, 51, 0.02);
+  border-color: var(--greyOpacity50);
+}
+
+.checkable__input:disabled:checked:before,
+.checkable__input:disabled[type='checkbox']:indeterminate:before {
+  background-color: #e5e8eb;
+  background-color: var(--grey200);
+  border-color: #e5e8eb;
+  border-color: var(--grey200);
+}
+
+.checkable__input[type='checkbox']:before {
+  border-radius: 6px;
+}
+
+.checkable__input[type='radio']:before {
+  border-radius: 12px;
+}
+
+.checkable__label-text {
+  display: inline-block;
+  padding-left: 8px;
+  padding-left: var(--checkable-label-text-padding);
+}
+
+.checkable--disabled > .checkable__input {
+  cursor: not-allowed;
+}
+
+.checkable--disabled > .checkable__label {
+  color: #b0b8c1;
+  color: var(--grey400);
+  cursor: not-allowed;
+}
+
+.checkable--read-only {
+  pointer-events: none;
+}
+
+.p-flex {
+  display: flex;
+}
+
+:root {
+  --pGridGutter: 24px;
+}
+
+.p-grid {
+  height: 100%;
+  display: flex;
+  flex-wrap: wrap;
+  margin-right: -24px;
+  margin-right: calc(var(--pGridGutter) * -1);
+}
+
+.p-grid-col {
+  flex-grow: 1;
+  padding-right: 24px;
+  padding-right: var(--pGridGutter);
+}
+
+.p-grid-col1 {
+  flex: 0 0 8.33333%;
+  max-width: 8.33333%;
+}
+
+.p-grid-col2 {
+  flex: 0 0 16.66667%;
+  max-width: 16.66667%;
+}
+
+.p-grid-col3 {
+  flex: 0 0 25%;
+  max-width: 25%;
+}
+
+.p-grid-col4 {
+  flex: 0 0 33.33333%;
+  max-width: 33.33333%;
+}
+
+.p-grid-col5 {
+  flex: 0 0 41.66667%;
+  max-width: 41.66667%;
+}

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -12,6 +12,8 @@ import Favorite from '@/pages/Favorite';
 import ErrorPage from '@/pages/Error';
 import CommonError from '@/interceptor/CommonError';
 import Watch from '@/pages/Watch';
+import CheckoutPage from '@/pages/Pay/Checkout';
+import SuccessPage from '@/pages/Pay/Success';
 
 /** 인증된 사용자만 접근 가능한 가드 */
 const RequireAuth = ({ children }: { children: React.ReactNode }) => {
@@ -67,5 +69,23 @@ export const router = createBrowserRouter([
       { path: 'error', element: <ErrorPage /> },
     ],
   },
+  {
+    path: 'payment',
+    children: [
+      {
+        index: true,
+        element: <Navigate to="/payment/checkout" replace />,
+      },
+      {
+        path: 'checkout',
+        element: <CheckoutPage />,
+      },
+      {
+        path: 'success',
+        element: <SuccessPage />,
+      },
+    ],
+  },
+
   { path: '*', element: <NotFound /> },
 ]);

--- a/src/types/comment.ts
+++ b/src/types/comment.ts
@@ -14,8 +14,8 @@ export interface Comment {
 
 /** 영화 리뷰 삭제 시 필요한 파라미터 */
 export type DeleteCommentParams = {
-  /** 영화 고유 ID */
-  movieId: number;
+  /** 댓글 고유 ID */
+  commentId: number;
   /** 사용자 ID */
   userId: string;
 };

--- a/src/types/pay.ts
+++ b/src/types/pay.ts
@@ -1,0 +1,13 @@
+/** 결제하기 데이터 타입 */
+export type AddPaymentData = {
+  /** 영화 포스터 이미지 URL */
+  imgUrl: string;
+  /** TMDB 영화 ID */
+  movieId: number;
+  /** 영화 제목 */
+  title: string;
+  /** 사용자 ID */
+  userId: string;
+  /** 결제 가격 */
+  price: number;
+};


### PR DESCRIPTION
## ✅ 구현 내용
**1. toss payment sdk 활용한 결제기능 구현**
   - 실제 결제까진 되지 않음. 데모용 구현 (실제 결제 구현을 위해선 사업자번호 필요한 문제)
   - 결제창 window.open으로 별도 브라우저 창으로 팝업
 
**2. BroadcastChannel API 활용하여 두 창간 데이터 공유**
   -  문제 : 결제창은 새로운 실행컨텍스트가 생성되어, 서비스창과 다른 React Query의 인스턴스를 갖는 문제
   -  해결 : BroadcastChannel API 활용하여, 결제창과 서비스 브라우저창의 데이터 공유하도록 처리

<br/>

<img width="568" alt="image" src="https://github.com/user-attachments/assets/b3faea46-5609-42aa-99f1-044f4cfd3984" />